### PR TITLE
adding return(out)

### DIFF
--- a/R/concord_hs_bec.R
+++ b/R/concord_hs_bec.R
@@ -247,6 +247,6 @@ concord_hs_bec <- function (sourcevar,
       pull(match)
     
   }
-  
+  return(out)
 }
 


### PR DESCRIPTION
thanks for the great pkg. I tried using it with concord_hs_bec with zero error but never return any output. Hopefully the return(out) fix this.